### PR TITLE
Fix flag emojis failing to upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "superjson": "^1.13.1",
     "transaction-exception": "^1.1.0",
     "trpc-openapi": "^1.2.0",
-    "twemoji": "^14.0.2",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/components/Tweemoji/TweemojiImage.tsx
+++ b/src/components/Tweemoji/TweemojiImage.tsx
@@ -1,11 +1,14 @@
 import Script from "next/script"
 import React, { createContext, useContext, useState } from "react"
 import { useRef, useEffect } from "react"
-import type Twemoji from "twemoji"
+
+interface Twemoji {
+	parse: (text: string) => string
+}
 
 declare global {
 	interface Window {
-		twemoji: typeof Twemoji | undefined
+		twemoji: Twemoji | undefined
 	}
 }
 

--- a/src/components/Tweemoji/TweemojiImage.tsx
+++ b/src/components/Tweemoji/TweemojiImage.tsx
@@ -1,21 +1,50 @@
+import Script from "next/script"
+import React, { createContext, useContext, useState } from "react"
 import { useRef, useEffect } from "react"
-import twemoji from "twemoji"
+import type Twemoji from "twemoji"
+
+declare global {
+	interface Window {
+		twemoji: typeof Twemoji | undefined
+	}
+}
 
 export const TwemojiImage = ({ emoji }: { emoji: string }) => {
 	const imgRef = useTweemojiImage(emoji)
-
 	return <div ref={imgRef} />
+}
+
+const TwemojiContext = createContext<Twemoji | undefined>(undefined)
+
+export const TwemojiProvider = ({ children }: { children: React.ReactNode }) => {
+	const [twemoji, setTwemoji] = useState<Twemoji | undefined>(undefined)
+
+	return (
+		<>
+			<Script
+				src="https://cdn.jsdelivr.net/npm/@twemoji/api@latest/dist/twemoji.min.js"
+				crossOrigin="anonymous"
+				onLoad={() => setTwemoji(window.twemoji)}
+			/>
+			<TwemojiContext.Provider value={twemoji}>{children}</TwemojiContext.Provider>
+		</>
+	)
 }
 
 /** Dynamically modifies the ref'd element into an img element with Tweemoji icon. */
 const useTweemojiImage = (emoji: string) => {
 	const imgRef = useRef<HTMLImageElement>(null)
+	const twemoji = useContext(TwemojiContext)
 
 	useEffect(() => {
-		if (imgRef.current) {
+		if (imgRef.current && twemoji === undefined) {
+			imgRef.current.textContent = emoji
+			return
+		}
+		if (imgRef.current && twemoji !== undefined) {
 			imgRef.current.innerHTML = twemoji.parse(emoji)
 		}
-	}, [emoji])
+	}, [emoji, twemoji])
 
 	return imgRef
 }

--- a/src/pages/languages.tsx
+++ b/src/pages/languages.tsx
@@ -3,14 +3,17 @@ import { LanguagesTable } from "../components/Language/LanguagesTable"
 import { type InferGetStaticPropsType } from "next"
 import { serverRouter } from "../utils/serverApi"
 import { LanguagePageHeading } from "../features/languages/LanguagePageHeading"
+import { TwemojiProvider } from "../components/Tweemoji/TweemojiImage"
 
 export default function Languages({ langData }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
 		<>
-			<Stack pl="sm" gap="xl" pt="xl" pb="xl" pr="sm">
-				<LanguagePageHeading />
-				<LanguagesTable data={langData} />
-			</Stack>
+			<TwemojiProvider>
+				<Stack pl="sm" gap="xl" pt="xl" pb="xl" pr="sm">
+					<LanguagePageHeading />
+					<LanguagesTable data={langData} />
+				</Stack>
+			</TwemojiProvider>
 		</>
 	)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,7 +91,6 @@ __metadata:
     transaction-exception: ^1.1.0
     trpc-openapi: ^1.2.0
     tsx: ^3.12.10
-    twemoji: ^14.0.2
     type-fest: ^4.9.0
     typescript: ^5.1.6
     vite: ^4.4.11
@@ -9869,17 +9868,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^8.0.1":
-  version: 8.1.0
-  resolution: "fs-extra@npm:8.1.0"
-  dependencies:
-    graceful-fs: ^4.2.0
-    jsonfile: ^4.0.0
-    universalify: ^0.1.0
-  checksum: bf44f0e6cea59d5ce071bba4c43ca76d216f89e402dc6285c128abc0902e9b8525135aa808adad72c9d5d218e9f4bcc63962815529ff2f684ad532172a284880
-  languageName: node
-  linkType: hard
-
 "fs-jetpack@npm:5.1.0":
   version: 5.1.0
   resolution: "fs-jetpack@npm:5.1.0"
@@ -11638,31 +11626,6 @@ jsdom@latest:
   version: 3.2.0
   resolution: "jsonc-parser@npm:3.2.0"
   checksum: 946dd9a5f326b745aa326d48a7257e3f4a4b62c5e98ec8e49fa2bdd8d96cef7e6febf1399f5c7016114fd1f68a1c62c6138826d5d90bc650448e3cf0951c53c7
-  languageName: node
-  linkType: hard
-
-"jsonfile@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "jsonfile@npm:4.0.0"
-  dependencies:
-    graceful-fs: ^4.1.6
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: 6447d6224f0d31623eef9b51185af03ac328a7553efcee30fa423d98a9e276ca08db87d71e17f2310b0263fd3ffa6c2a90a6308367f661dc21580f9469897c9e
-  languageName: node
-  linkType: hard
-
-"jsonfile@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "jsonfile@npm:5.0.0"
-  dependencies:
-    graceful-fs: ^4.1.6
-    universalify: ^0.1.2
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: e0ecff572dba34153a66e3a3bc5c6cb01a2c1d2cf4a2c19b6728dcfcab39d94be9cca4a0fc86a17ff2c815f2aeb43768ac75545780dbea4009433fdc32aa14d1
   languageName: node
   linkType: hard
 
@@ -16816,25 +16779,6 @@ jsdom@latest:
   languageName: node
   linkType: hard
 
-"twemoji-parser@npm:14.0.0":
-  version: 14.0.0
-  resolution: "twemoji-parser@npm:14.0.0"
-  checksum: 8eede69cf71f94735de7b6fddf5dfbfe3cb2e01baefc3201360984ccc97cfc659f206c8f73bd1405a2282779af3b79a8c9bed3864c672e15e2dc6f8ce4810452
-  languageName: node
-  linkType: hard
-
-"twemoji@npm:^14.0.2":
-  version: 14.0.2
-  resolution: "twemoji@npm:14.0.2"
-  dependencies:
-    fs-extra: ^8.0.1
-    jsonfile: ^5.0.0
-    twemoji-parser: 14.0.0
-    universalify: ^0.1.2
-  checksum: 686a356a7af3cf15f7894568bfcdfafcea0cd45473b3f8c59d6ca95e549695f1222845d1a8c39ffa3bc4057e9d59e41ab83e4ce3cbcd68823ff50d57e3ff58da
-  languageName: node
-  linkType: hard
-
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -17156,13 +17100,6 @@ jsdom@latest:
     unist-util-is: ^4.0.0
     unist-util-visit-parents: ^3.0.0
   checksum: 1fe19d500e212128f96d8c3cfa3312846e586b797748a1fd195fe6479f06bc90a6f6904deb08eefc00dd58e83a1c8a32fb8677252d2273ad7a5e624525b69b8f
-  languageName: node
-  linkType: hard
-
-"universalify@npm:^0.1.0, universalify@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "universalify@npm:0.1.2"
-  checksum: 40cdc60f6e61070fe658ca36016a8f4ec216b29bf04a55dce14e3710cc84c7448538ef4dad3728d0bfe29975ccd7bfb5f414c45e7b78883567fb31b246f02dff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Fixes #11 
- Changed dependency to use script tag instead of npm package for latest updates
- Add handling to default to native emoji string if twemoji is unable to load